### PR TITLE
Avoid busy loop when receiving incoming stream data.

### DIFF
--- a/pygerrit/stream.py
+++ b/pygerrit/stream.py
@@ -57,13 +57,17 @@ class GerritStream(Thread):
         stdout = channel.makefile()
         stderr = channel.makefile_stderr()
         while not self._stop.is_set():
-            if channel.exit_status_ready():
-                if channel.recv_stderr_ready():
-                    error = stderr.readline().strip()
+            try:
+                if channel.exit_status_ready():
+                    if channel.recv_stderr_ready():
+                        error = stderr.readline().strip()
+                    else:
+                        error = "Remote server connection closed"
+                    self._error_event(error)
+                    self._stop.set()
                 else:
-                    error = "Remote server connection closed"
-                self._error_event(error)
+                    data = stdout.readline()
+                    self._gerrit.put_event(data)
+            except Exception as e:
+                self._error_event(repr(e))
                 self._stop.set()
-            else:
-                data = stdout.readline()
-                self._gerrit.put_event(data)


### PR DESCRIPTION
Checking whether bytes are available is a non-blocking operation,
causing the receive loop to become a busy loop.

The busy loop essentially takes up a full cpu 100% of the time.

Perhaps this should be tied to a blocking setting?
