### PR TITLE
fix for hanging connections

### DIFF
--- a/pygerrit/stream.py
+++ b/pygerrit/stream.py
@@ -41,10 +41,12 @@ class GerritStream(Thread):
         self._gerrit = gerrit
         self._ssh_client = ssh_client
         self._stop = Event()
+        self._channel = None
 
     def stop(self):
         """ Stop the thread. """
         self._stop.set()
+        self._channel.close()
 
     def _error_event(self, error):
         """ Dispatch `error` to the Gerrit client. """
@@ -53,6 +55,7 @@ class GerritStream(Thread):
     def run(self):
         """ Listen to the stream and send events to the client. """
         channel = self._ssh_client.get_transport().open_session()
+        self._channel = channel
         channel.exec_command("gerrit stream-events")
         stdout = channel.makefile()
         stderr = channel.makefile_stderr()


### PR DESCRIPTION
Hey David,

when i was trying to use your module, i noticed, that i could not use stop_stream_events() to stop reading events, because stream.py was waiting forever for a ssh-data.

Hope my patch is not too ugly and you could consider it for application.
regards, Joe
## 
# start example code:

def main():
    client = GerritClient("gerrit")
    print client.gerrit_version()

```
client.start_event_stream()
try:
    print "starting loop"
    while True:
        print "waiting for event"
        event = client.get_event(block=True, timeout=1) #1sec

except:
    print "received stop"
    client.stop_event_stream()
```
# end example
## 

--> Now interrupting with Ctrl-c
