### PR TITLE
Update examples to use argparse instead of optparse

### DIFF
--- a/example.py
+++ b/example.py
@@ -26,7 +26,7 @@
 """ Example of using the Gerrit client class. """
 
 import logging
-import optparse
+import argparse
 import sys
 from threading import Event
 import time
@@ -37,29 +37,29 @@ from pygerrit.events import ErrorEvent
 
 
 def _main():
-    usage = "usage: %prog [options]"
-    parser = optparse.OptionParser(usage=usage)
-    parser.add_option('-g', '--gerrit-hostname', dest='hostname',
-                      default='review',
-                      help='gerrit server hostname (default: %default)')
-    parser.add_option('-p', '--port', dest='port',
-                      type='int', default=29418,
-                      help='port number (default: %default)')
-    parser.add_option('-u', '--username', dest='username',
-                      help='username')
-    parser.add_option('-b', '--blocking', dest='blocking',
-                      action='store_true',
-                      help='block on event get (default: False)')
-    parser.add_option('-t', '--timeout', dest='timeout',
-                      default=None, type='int',
-                      help='timeout (seconds) for blocking event get '
-                           '(default: None)')
-    parser.add_option('-v', '--verbose', dest='verbose',
-                      action='store_true',
-                      help='enable verbose (debug) logging')
-    parser.add_option('-i', '--ignore-stream-errors', dest='ignore',
-                      action='store_true',
-                      help='do not exit when an error event is received')
+    descr = 'Send request using Gerrit ssh API'
+    parser = argparse.ArgumentParser(description=descr)
+    parser.add_argument('-g', '--gerrit-hostname', dest='hostname',
+                        default='review',
+                        help='gerrit server hostname (default: %default)')
+    parser.add_argument('-p', '--port', dest='port',
+                        type='int', default=29418,
+                        help='port number (default: %default)')
+    parser.add_argument('-u', '--username', dest='username',
+                        help='username')
+    parser.add_argument('-b', '--blocking', dest='blocking',
+                        action='store_true',
+                        help='block on event get (default: False)')
+    parser.add_argument('-t', '--timeout', dest='timeout',
+                        default=None, type='int',
+                        help='timeout (seconds) for blocking event get '
+                        '(default: None)')
+    parser.add_argument('-v', '--verbose', dest='verbose',
+                        action='store_true',
+                        help='enable verbose (debug) logging')
+    parser.add_argument('-i', '--ignore-stream-errors', dest='ignore',
+                        action='store_true',
+                        help='do not exit when an error event is received')
 
     (options, _args) = parser.parse_args()
     if options.timeout and not options.blocking:

--- a/rest_example.py
+++ b/rest_example.py
@@ -26,7 +26,7 @@
 """ Example of using the Gerrit client REST API. """
 
 import logging
-import optparse
+import argparse
 import sys
 
 from requests.auth import HTTPBasicAuth, HTTPDigestAuth
@@ -44,37 +44,34 @@ from pygerrit.rest.auth import HTTPDigestAuthFromNetrc, HTTPBasicAuthFromNetrc
 
 
 def _main():
-    usage = "usage: %prog [options]"
-    parser = optparse.OptionParser(usage=usage)
-
-    parser.add_option('-g', '--gerrit-url', dest='gerrit_url',
-                      help='gerrit server url')
-    parser.add_option('-b', '--basic-auth', dest='basic_auth',
-                      action='store_true',
-                      help='use basic auth instead of digest')
+    descr = 'Send request using Gerrit HTTP API'
+    parser = argparse.ArgumentParser(description=descr)
+    parser.add_argument('-g', '--gerrit-url', dest='gerrit_url',
+                        required=True,
+                        help='gerrit server url')
+    parser.add_argument('-b', '--basic-auth', dest='basic_auth',
+                        action='store_true',
+                        help='use basic auth instead of digest')
     if _kerberos_support:
-        parser.add_option('-k', '--kerberos-auth', dest='kerberos_auth',
-                          action='store_true',
-                          help='use kerberos auth')
-    parser.add_option('-u', '--username', dest='username',
-                      help='username')
-    parser.add_option('-p', '--password', dest='password',
-                      help='password')
-    parser.add_option('-n', '--netrc', dest='netrc',
-                      action='store_true',
-                      help='Use credentials from netrc')
-    parser.add_option('-v', '--verbose', dest='verbose',
-                      action='store_true',
-                      help='enable verbose (debug) logging')
+        parser.add_argument('-k', '--kerberos-auth', dest='kerberos_auth',
+                            action='store_true',
+                            help='use kerberos auth')
+    parser.add_argument('-u', '--username', dest='username',
+                        help='username')
+    parser.add_argument('-p', '--password', dest='password',
+                        help='password')
+    parser.add_argument('-n', '--netrc', dest='netrc',
+                        action='store_true',
+                        help='Use credentials from netrc')
+    parser.add_argument('-v', '--verbose', dest='verbose',
+                        action='store_true',
+                        help='enable verbose (debug) logging')
 
     (options, _args) = parser.parse_args()
 
     level = logging.DEBUG if options.verbose else logging.INFO
     logging.basicConfig(format='%(asctime)s %(levelname)s %(message)s',
                         level=level)
-
-    if not options.gerrit_url:
-        parser.error("Must specify Gerrit URL with --gerrit-url")
 
     if _kerberos_support and options.kerberos_auth:
         if options.username or options.password \


### PR DESCRIPTION
optparse was deprecated since 2.7 and removed in python 3
