### PR TITLE
Set requests requirements to >= 2.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ ecdsa==0.11
 paramiko==1.14.0
 pbr==0.8.0
 pycrypto==2.3
-requests==2.4.1
+requests>=2.4


### PR DESCRIPTION
Be less strict on version dependency requirement for requests. Today requests in on 2.4.3 version.
