### PR TITLE
Allow unicode characters in gerrit commands

### DIFF
--- a/pygerrit/ssh.py
+++ b/pygerrit/ssh.py
@@ -171,6 +171,12 @@ class GerritSSHClient(SSHClient):
             raise ValueError("command must be a string")
         gerrit_command = "gerrit " + command
 
+        # are we sending non-ascii data?
+        try:
+            gerrit_command.encode('ascii')
+        except UnicodeEncodeError:
+            gerrit_command = gerrit_command.encode('utf-8')
+
         self._connect()
         try:
             stdin, stdout, stderr = self.exec_command(gerrit_command,


### PR DESCRIPTION
Trying to use pygerrit to submit reviews fails if there
is a unicode character in the review comment. This change
sees if the message is valid ascii, and if it's not,
encodes as utf-8.