### PR TITLE
Add keepalive support to GerritSSHClient

### DIFF
--- a/pygerrit/client.py
+++ b/pygerrit/client.py
@@ -40,14 +40,19 @@ class GerritClient(object):
     :arg str host: The hostname.
     :arg str username: (optional) The username to use when connecting.
     :arg str port: (optional) The port number to connect to.
+    :arg int keepalive: (optional) Keepalive interval in seconds.
 
     """
 
-    def __init__(self, host, username=None, port=None):
+    def __init__(self, host, username=None, port=None, keepalive=None):
         self._factory = GerritEventFactory()
         self._events = Queue()
         self._stream = None
-        self._ssh_client = GerritSSHClient(host, username=username, port=port)
+        self.keepalive = keepalive
+        self._ssh_client = GerritSSHClient(host,
+                                           username=username,
+                                           port=port,
+                                           keepalive=keepalive)
 
     def gerrit_version(self):
         """ Get the Gerrit version.

--- a/pygerrit/ssh.py
+++ b/pygerrit/ssh.py
@@ -65,7 +65,7 @@ class GerritSSHClient(SSHClient):
 
     """ Gerrit SSH Client, wrapping the paramiko SSH Client. """
 
-    def __init__(self, hostname, username=None, port=None):
+    def __init__(self, hostname, username=None, port=None, keepalive=None):
         """ Initialise and connect to SSH. """
         super(GerritSSHClient, self).__init__()
         self.remote_version = None
@@ -76,6 +76,7 @@ class GerritSSHClient(SSHClient):
         self.connected = Event()
         self.lock = Lock()
         self.proxy = None
+        self.keepalive = keepalive
 
     def _configure(self):
         """ Configure the ssh parameters from the config file. """
@@ -136,6 +137,8 @@ class GerritSSHClient(SSHClient):
                 # waiting to acquire the lock
                 if not self.connected.is_set():
                     self._do_connect()
+                    if self.keepalive:
+                        self._transport.set_keepalive(self.keepalive)
                     self.connected.set()
             except GerritError:
                 raise


### PR DESCRIPTION
This will allow keeping the SSH sessions alive for a duration of time longer
than the timeout configured for the server.