### PR TITLE
Updated add_comment()

### DIFF
--- a/pygerrit/rest/__init__.py
+++ b/pygerrit/rest/__init__.py
@@ -248,15 +248,29 @@ class GerritReview(object):
                            'line': 10,
                            'message': 'inline message'}])
 
+            add_comments([{'filename': 'Makefile',
+                           'range': { 'start_line': 0,
+                                      'start_character': 1,
+                                      'end_line': 0,
+                                      'end_character': 5 },
+                           'message': 'inline message'}])
+
         """
         for comment in comments:
-            if 'filename' and 'line' and 'message' in comment.keys():
-                line_msg = {"line": comment['line'],
-                            "message": comment['message']}
-                file_comment = {comment['filename']: [line_msg]}
+            if 'filename' and 'message' in comment.keys():
+                msg = {}
+                if 'range' in comment.keys():
+                    msg = { "range": comment['range'],
+                            "message": comment['message'] }
+                elif 'line' in comment.keys():
+                    msg = { "line": comment['line'],
+                            "message": comment['message'] }
+                else:
+                    continue
+                file_comment = {comment['filename']: [msg]}
                 if self.comments:
                     if comment['filename'] in self.comments.keys():
-                        self.comments[comment['filename']].append(line_msg)
+                        self.comments[comment['filename']].append(msg)
                     else:
                         self.comments.update(file_comment)
                 else:


### PR DESCRIPTION
add_comment() now supports 'ranges' as described by the gerrit API, by
using the keyword 'range' instead of 'line', and a dict with the four
required keys.