### PR TITLE
merging request headers in REST API calls

### DIFF
--- a/pygerrit/rest/__init__.py
+++ b/pygerrit/rest/__init__.py
@@ -53,6 +53,27 @@ def _decode_response(response):
         raise
 
 
+def _merge_dict(result, overrides):
+    """ Deep-merge dictionaries
+
+    :arg dict result: The resulting dictionary
+    :arg dict overrides: Dictionay being merged into the result
+
+    :returns:
+        The resulting dictionary
+    """
+    for key in overrides:
+        if (
+            key in result and
+            isinstance(result[key], dict) and
+            isinstance(overrides[key], dict)
+        ):
+            _merge_dict(result[key], overrides[key])
+        else:
+            result[key] = overrides[key]
+    return result
+
+
 class GerritRestAPI(object):
 
     """ Interface to the Gerrit REST API.
@@ -130,10 +151,17 @@ class GerritRestAPI(object):
             requests.RequestException on timeout or connection error.
 
         """
-        kwargs.update(self.kwargs.copy())
+        args = {}
         if "data" in kwargs:
-            kwargs["headers"].update(
-                {"Content-Type": "application/json;charset=UTF-8"})
+            _merge_dict(
+                args, {
+                    "headers": {
+                        "Content-Type": "application/json;charset=UTF-8"
+                    }
+                }
+            )
+        _merge_dict(args, self.kwargs.copy())
+        _merge_dict(args, kwargs)
         response = requests.put(self.make_url(endpoint), **kwargs)
         return _decode_response(response)
 
@@ -149,11 +177,18 @@ class GerritRestAPI(object):
             requests.RequestException on timeout or connection error.
 
         """
-        kwargs.update(self.kwargs.copy())
+        args = {}
         if "data" in kwargs:
-            kwargs["headers"].update(
-                {"Content-Type": "application/json;charset=UTF-8"})
-        response = requests.post(self.make_url(endpoint), **kwargs)
+            _merge_dict(
+                args, {
+                    "headers": {
+                        "Content-Type": "application/json;charset=UTF-8"
+                    }
+                }
+            )
+        _merge_dict(args, self.kwargs.copy())
+        _merge_dict(args, kwargs)
+        response = requests.post(self.make_url(endpoint), **args)
         return _decode_response(response)
 
     def delete(self, endpoint, **kwargs):
@@ -168,7 +203,17 @@ class GerritRestAPI(object):
             requests.RequestException on timeout or connection error.
 
         """
-        kwargs.update(self.kwargs.copy())
+        args = {}
+        if "data" in kwargs:
+            _merge_dict(
+                args, {
+                    "headers": {
+                        "Content-Type": "application/json;charset=UTF-8"
+                    }
+                }
+            )
+        _merge_dict(args, self.kwargs.copy())
+        _merge_dict(args, kwargs)
         response = requests.delete(self.make_url(endpoint), **kwargs)
         return _decode_response(response)
 


### PR DESCRIPTION
Some of Gerrit's REST APIs expect requests with Content-Type different than 'application/json'. Configuring SSH keys is a good example (/accounts/self/sshkeys/).

This PR allows the caller of REST API to provide headers (including Content-Type) which will then override defaults specified in pygerrit.