### PR TITLE
Convert 'content' from byte to string if necessary

### DIFF
--- a/pygerrit/rest/__init__.py
+++ b/pygerrit/rest/__init__.py
@@ -42,6 +42,8 @@ def _decode_response(response):
 
     """
     content = response.content.strip()
+    if not isinstance(content, str):
+        content = content.decode('utf-8')
     logging.debug(content[:512])
     response.raise_for_status()
     if content.startswith(GERRIT_MAGIC_JSON_PREFIX):


### PR DESCRIPTION
In python3 `content` variable contains byte and `GERRIT_MAGIC_JSON_PREFIX` contains string, so the current code raises on line 47 (former), this simple check should fix the issue