### PR TITLE
Add support for automatically adding known_hosts

### DIFF
--- a/pygerrit/client.py
+++ b/pygerrit/client.py
@@ -37,14 +37,17 @@ class GerritClient(object):
 
     """ Gerrit client interface.
 
-    :arg str host: The hostname.
-    :arg str username: (optional) The username to use when connecting.
-    :arg str port: (optional) The port number to connect to.
-    :arg int keepalive: (optional) Keepalive interval in seconds.
+    :arg str  host: The hostname.
+    :arg str  username: (optional) The username to use when connecting.
+    :arg str  port: (optional) The port number to connect to.
+    :arg int  keepalive: (optional) Keepalive interval in seconds.
+    :arg bool auto_add_hosts: (optional) If True, the ssh client will
+                              automatically add hosts to known_hosts.
 
     """
 
-    def __init__(self, host, username=None, port=None, keepalive=None):
+    def __init__(self, host, username=None, port=None,
+                 keepalive=None, auto_add_hosts=False):
         self._factory = GerritEventFactory()
         self._events = Queue()
         self._stream = None
@@ -52,7 +55,8 @@ class GerritClient(object):
         self._ssh_client = GerritSSHClient(host,
                                            username=username,
                                            port=port,
-                                           keepalive=keepalive)
+                                           keepalive=keepalive,
+                                           auto_add_hosts=auto_add_hosts)
 
     def gerrit_version(self):
         """ Get the Gerrit version.

--- a/pygerrit/ssh.py
+++ b/pygerrit/ssh.py
@@ -29,7 +29,7 @@ from threading import Event, Lock
 
 from .error import GerritError
 
-from paramiko import SSHClient, SSHConfig, ProxyCommand
+from paramiko import AutoAddPolicy, SSHClient, SSHConfig, ProxyCommand
 from paramiko.ssh_exception import SSHException
 
 
@@ -65,7 +65,8 @@ class GerritSSHClient(SSHClient):
 
     """ Gerrit SSH Client, wrapping the paramiko SSH Client. """
 
-    def __init__(self, hostname, username=None, port=None, keepalive=None):
+    def __init__(self, hostname, username=None, port=None,
+                 keepalive=None, auto_add_hosts=False):
         """ Initialise and connect to SSH. """
         super(GerritSSHClient, self).__init__()
         self.remote_version = None
@@ -77,6 +78,8 @@ class GerritSSHClient(SSHClient):
         self.lock = Lock()
         self.proxy = None
         self.keepalive = keepalive
+        if auto_add_hosts:
+            self.set_missing_host_key_policy(AutoAddPolicy())
 
     def _configure(self):
         """ Configure the ssh parameters from the config file. """


### PR DESCRIPTION
Currently, if a server is not in the known_hosts file then
the client will fail with an error like:

paramiko.SSHException: Server '[<host>]:<port>' not found in known_hosts

This change allows users to configure paramiko with the AutoAddPolicy().
It should be noted that using this policy opens users to
man-in-the-middle attacks, which is why it is an optional setting and
defaults to False.