### PR TITLE
Adding parents/related info for a patchset

### DIFF
--- a/pygerrit/models.py
+++ b/pygerrit/models.py
@@ -93,6 +93,7 @@ class Patchset(object):
         self.number = from_json(json_data, "number")
         self.revision = from_json(json_data, "revision")
         self.ref = from_json(json_data, "ref")
+        self.parents = from_json(json_data, "parents")
         self.uploader = Account.from_json(json_data, "uploader")
 
     def __repr__(self):


### PR DESCRIPTION
I am not sure if there is any other way to get to info about parents or related info in RestAPI terms. Adding the below line, seems to be fixing this issue.

RestAPI: http://gerrit-documentation.storage.googleapis.com/Documentation/2.15/rest-api-changes.html#get-related-changes